### PR TITLE
[patch] bump pytorch and nltk versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 allennlp[all] @ git+https://github.com/allenai/allennlp.git@main
 
-torch>=1.7.0
+torch>=2.0.1
 
 # For structured prediction.
 conllu>=4.4.2
@@ -8,7 +8,7 @@ conllu>=4.4.2
 # For RC models
 word2number>=1.1
 py-rouge==1.1
-nltk>=3.6.5
+nltk>=3.8.1
 
 # For CNN/DailyMail dataset reader
 ftfy


### PR DESCRIPTION
Updates to allign pytorch and nltk in [coe_allennlp-models](https://github.com/ciso-appsec/coe_allennlp-models) to match [coe_allennlp](https://github.com/ciso-appsec/coe_allennlp)

https://github.com/ciso-appsec/coe_allennlp/pull/1/files